### PR TITLE
Updated doctype

### DIFF
--- a/views/home.jade
+++ b/views/home.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
 	head
 		title Chat


### PR DESCRIPTION
Fixes the `doctype 5` is deprecated, you must now use `doctype html` when Jade 1.1.5.
